### PR TITLE
Use recursive clone to resolve submodule references.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,14 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+ingest-accessioner
+ingest-broker
+ingest-core
+ingest-exporter
+ingest-kube-deployment
+ingest-staging-manager
+ingest-validator
+
 # User-specific stuff:
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Configuration files for deploying the Ingestion Service on  [Kubernetes](https:/
 3. Start the Minikube cluster: `minikube start`
 4. Set up a shell to use the Minikube docker-daemon: `eval $(minikube docker-env)`
 
-For the next steps there is a script that can be run: [setup.sh](setup.sh). This should call all the comments needed in order but has no error checking as yet.
+For the next steps there is a script that can be run: [setup.sh](setup.sh). This should call all the comments needed in order but has no error checking as yet. NOTE: An SSH key must be linked with your Github account for this script to work correctly.
 
 5. Clone and build each repository. `cd` into each and run `docker build -t <repository-name>:local .`
     * ingest-core `docker build -t ingest-core:local .`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Configuration files for deploying the Ingestion Service on  [Kubernetes](https:/
 1. [Install Docker](https://docs.docker.com/engine/installation/)
 2. [Install Minikube and prerequisites](https://kubernetes.io/docs/tasks/tools/install-minikube/):
     * [Install Virtual Box](https://www.virtualbox.org/wiki/Downloads)
-    * [Install kubecrl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+    * [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
     * [Install Minikube](https://github.com/kubernetes/minikube/releases)
 3. Start the Minikube cluster: `minikube start`
 4. Set up a shell to use the Minikube docker-daemon: `eval $(minikube docker-env)`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Configuration files for deploying the Ingestion Service on  [Kubernetes](https:/
 3. Start the Minikube cluster: `minikube start`
 4. Set up a shell to use the Minikube docker-daemon: `eval $(minikube docker-env)`
 
-For the next steps there is a script that can be run: [setup.sh](setup.sh). This should call all the comments needed in order but has no error checking as yet. NOTE: An SSH key must be linked with your Github account for this script to work correctly.
+For the next steps there is a script that can be run: [setup.sh](setup.sh). This should call all the comments needed in order but has no error checking as yet.
 
 5. Clone and build each repository. `cd` into each and run `docker build -t <repository-name>:local .`
     * ingest-core `docker build -t ingest-core:local .`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Configuration files for deploying the Ingestion Service on  [Kubernetes](https:/
 3. Start the Minikube cluster: `minikube start`
 4. Set up a shell to use the Minikube docker-daemon: `eval $(minikube docker-env)`
 
-For the next steps there is a script that can be run: [setup.sh](setup.sh). This should call all the comments needed in order but has no error checking as yet.
+For the next steps there is a script that can be run: [setup.sh](setup.sh). This should call all the commands needed in order but has no error checking as yet.
 
 5. Clone and build each repository. `cd` into each and run `docker build -t <repository-name>:local .`
     * ingest-core `docker build -t ingest-core:local .`

--- a/setup.sh
+++ b/setup.sh
@@ -1,22 +1,23 @@
 #!/usr/bin/env bash
+
 # clone all git repos (via HTTPS)
-git clone https://github.com/HumanCellAtlas/ingest-kube-deployment.git
-git clone https://github.com/HumanCellAtlas/ingest-core.git
-git clone https://github.com/HumanCellAtlas/ingest-broker.git
-git clone https://github.com/HumanCellAtlas/ingest-accessioner.git
-git clone https://github.com/HumanCellAtlas/ingest-validator.git
+git clone https://github.com/IGS/ingest-kube-deployment.git
+git clone https://github.com/IGS/ingest-core.git
+git clone https://github.com/IGS/ingest-broker.git
+git clone https://github.com/IGS/ingest-accessioner.git
+git clone https://github.com/IGS/ingest-validator.git
 
 # The following 2 repos make use of git submodules that would normally require
 # a git clone with a --recursive flag. However, the submodules are defined with
 # github URLs that require ssh keys. Here we work around that by obtaining the
 # code and cloning it into an "ingestbroker" subdirectory.
-git clone https://github.com/HumanCellAtlas/ingest-exporter.git && \
+git clone https://github.com/IGS/ingest-exporter.git && \
     pushd ingest-exporter && \
-    git clone http://github.com/HumanCellAtlas/ingest-broker.git ingestbroker && \
+    git clone http://github.com/IGS/ingest-broker.git ingestbroker && \
     popd
-git clone https://github.com/HumanCellAtlas/ingest-staging-manager.git && \
+git clone https://github.com/IGS/ingest-staging-manager.git && \
     pushd ingest-staging-manager && \
-    git clone https://github.com/HumanCellAtlas/ingest-broker.git ingestbroker && \
+    git clone https://github.com/IGS/ingest-broker.git ingestbroker && \
     popd
 
 # build images

--- a/setup.sh
+++ b/setup.sh
@@ -5,8 +5,20 @@ git clone https://github.com/HumanCellAtlas/ingest-core.git
 git clone https://github.com/HumanCellAtlas/ingest-broker.git
 git clone https://github.com/HumanCellAtlas/ingest-accessioner.git
 git clone https://github.com/HumanCellAtlas/ingest-validator.git
-git clone --recursive https://github.com/HumanCellAtlas/ingest-exporter.git
-git clone --recursive https://github.com/HumanCellAtlas/ingest-staging-manager.git
+
+# The following 2 repos make use of git submodules that would normally require
+# a git clone with a --recursive flag. However, the submodules are defined with
+# github URLs that require ssh keys. Here we work around that by obtaining the
+# code and cloning it into an "ingestbroker" subdirectory.
+git clone https://github.com/HumanCellAtlas/ingest-exporter.git && \
+    pushd ingest-exporter && \
+    git clone http://github.com/HumanCellAtlas/ingest-broker.git ingestbroker && \
+    popd
+git clone https://github.com/HumanCellAtlas/ingest-staging-manager.git && \
+    pushd ingest-staging-manager && \
+    git clone https://github.com/HumanCellAtlas/ingest-broker.git ingestbroker && \
+    popd
+
 # build images
 cd ingest-core
 docker build -t ingest-core:local .
@@ -20,6 +32,7 @@ cd ../ingest-exporter
 docker build -t ingest-exporter:local .
 cd ../ingest-staging-manager
 docker build -t ingest-staging-manager:local .
+
 # Apply Kubernetes configs
 cd ../ingest-kube-deployment/local-dev/ingestion
 kubectl apply -f service-rabbit-deploy.yml
@@ -34,9 +47,13 @@ kubectl apply -f ingest-accessioner-deploy.yml
 kubectl apply -f ingest-validator-deploy.yml
 kubectl apply -f ingest-exporter-deploy.yml
 kubectl apply -f ingest-staging-manager-deploy.yml
-# Minikube Dashboard
+
+# Minikube Dashboard. This invoke's the user's default browser to the dashboard's
+# URL.
 minikube dashboard
+
 # Check Ingest API
 minikube service ingest-core-service --url
+
 # Check Demo UP
 minikube service ingest-demo-service --url

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# clone all git repos
-git clone git@github.com:HumanCellAtlas/ingest-kube-deployment.git
-git clone git@github.com:HumanCellAtlas/ingest-core.git
-git clone git@github.com:HumanCellAtlas/ingest-broker.git
-git clone git@github.com:HumanCellAtlas/ingest-accessioner.git
-git clone git@github.com:HumanCellAtlas/ingest-validator.git
-git clone --recursive git@github.com:HumanCellAtlas/ingest-exporter.git
-git clone --recursive git@github.com:HumanCellAtlas/ingest-staging-manager.git
+# clone all git repos (via HTTPS)
+git clone https://github.com:HumanCellAtlas/ingest-kube-deployment.git
+git clone https://github.com:HumanCellAtlas/ingest-core.git
+git clone https://github.com:HumanCellAtlas/ingest-broker.git
+git clone https://github.com:HumanCellAtlas/ingest-accessioner.git
+git clone https://github.com:HumanCellAtlas/ingest-validator.git
+git clone --recursive https://github.com:HumanCellAtlas/ingest-exporter.git
+git clone --recursive https://github.com:HumanCellAtlas/ingest-staging-manager.git
 # build images
 cd ingest-core
 docker build -t ingest-core:local .

--- a/setup.sh
+++ b/setup.sh
@@ -5,8 +5,8 @@ git clone git@github.com:HumanCellAtlas/ingest-core.git
 git clone git@github.com:HumanCellAtlas/ingest-broker.git
 git clone git@github.com:HumanCellAtlas/ingest-accessioner.git
 git clone git@github.com:HumanCellAtlas/ingest-validator.git
-git clone git@github.com:HumanCellAtlas/ingest-exporter.git
-git clone git@github.com:HumanCellAtlas/ingest-staging-manager.git
+git clone --recursive git@github.com:HumanCellAtlas/ingest-exporter.git
+git clone --recursive git@github.com:HumanCellAtlas/ingest-staging-manager.git
 # build images
 cd ingest-core
 docker build -t ingest-core:local .

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # clone all git repos (via HTTPS)
-git clone https://github.com:HumanCellAtlas/ingest-kube-deployment.git
-git clone https://github.com:HumanCellAtlas/ingest-core.git
-git clone https://github.com:HumanCellAtlas/ingest-broker.git
-git clone https://github.com:HumanCellAtlas/ingest-accessioner.git
-git clone https://github.com:HumanCellAtlas/ingest-validator.git
-git clone --recursive https://github.com:HumanCellAtlas/ingest-exporter.git
-git clone --recursive https://github.com:HumanCellAtlas/ingest-staging-manager.git
+git clone https://github.com/HumanCellAtlas/ingest-kube-deployment.git
+git clone https://github.com/HumanCellAtlas/ingest-core.git
+git clone https://github.com/HumanCellAtlas/ingest-broker.git
+git clone https://github.com/HumanCellAtlas/ingest-accessioner.git
+git clone https://github.com/HumanCellAtlas/ingest-validator.git
+git clone --recursive https://github.com/HumanCellAtlas/ingest-exporter.git
+git clone --recursive https://github.com/HumanCellAtlas/ingest-staging-manager.git
 # build images
 cd ingest-core
 docker build -t ingest-core:local .


### PR DESCRIPTION
Minikube deployment as described in the README doesn't work unless the submodule references in ingest-exporter and ingest-staging-manager are resolved/expanded somehow. Recursive clone seems to be the most expedient way to accomplish this.