### PR TITLE
Adding gitlab.yaml files

### DIFF
--- a/.gitlab-ci-prod.yml
+++ b/.gitlab-ci-prod.yml
@@ -12,6 +12,4 @@ deploy_ingest:
   only:
     refs:
       - prod
-  tags:
-    - purple
   when: manual

--- a/.gitlab-ci-prod.yml
+++ b/.gitlab-ci-prod.yml
@@ -1,0 +1,17 @@
+image: rhiananthony/dsde-toolbox:gitlab-runner-11.4.4
+
+stages:
+  - deploy
+
+deploy_ingest:
+  stage: deploy
+  script:
+    - source config/environment_${ENVIRONMENT}
+    - cd apps
+    - for APPLICATION in ${APPLICATION_LIST}; do make deploy-app-${APPLICATION}; done
+  only:
+    refs:
+      - prod
+  tags:
+    - purple
+  when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,4 @@ deploy_ingest:
       - dev
       - integration
       - staging
-  tags:
-    - purple
   when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,19 @@
+image: rhiananthony/dsde-toolbox:gitlab-runner-11.4.4
+
+stages:
+  - deploy
+
+deploy_ingest:
+  stage: deploy
+  script:
+    - source config/environment_${ENVIRONMENT}
+    - cd apps
+    - for APPLICATION in ${APPLICATION_LIST}; do make deploy-app-${APPLICATION}; done
+  only:
+    refs:
+      - dev
+      - integration
+      - staging
+  tags:
+    - purple
+  when: manual


### PR DESCRIPTION
Two environment variables would need to be passed when the Gitlab job is run. The first is the ENVIRONMENT that you want to deploy to, and the second is the list of APPLICATIONS that you want to deploy (ingest-ui, ingest-validator, etc...). This second list should only be separated by spaces, i.e. "ingest-core ingest-broker ingest-validator ingest-ui". If helm acts the same as kubernetes (that is - if it only applies changes to yaml files) then you could potentially remove the need for this second variable by changing the script called to instead use "make deploy-all-apps" or even "make deploy-all". I was unsure about this. 

I talked with Lon and it looks like we may not need to make any changes to the GitLab runner. According to Lon it already has:
1) An AWS access key/secret key which may allow access to the AWS Kubernetes cluster, 
2) Helm, 
3) Make. 

So, if we can approve this PR we can test it out. 

